### PR TITLE
Fix build with newer compilers and out of source

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,8 +86,9 @@ set(CMAKE_CXX_STANDARD 14)
 foreach(TEST_FILE ${TEST_SRCS})
   SET(TEST_EXE "${TEST_FILE}.x")
   add_executable(${TEST_EXE} ${TEST_FILE})
-  target_compile_options(${TEST_EXE} PUBLIC -Wall -Wextra -Werror -Wfatal-errors) #-Wpedantic
-  target_include_directories(${TEST_EXE} PUBLIC "../../../..")
+  # Newer compilers give waring in boost/archive/helper_collection.hpp and fail so -Werror can't be used
+  target_compile_options(${TEST_EXE} PUBLIC -Wall -Wextra -Wfatal-errors) #-Wpedantic
+  target_include_directories(${TEST_EXE} PUBLIC "${CMAKE_PROJECT_SOURCE_DIR}/..")
 
   list(FIND NEED_BOOST_SERIALIZATION_SRCS ${TEST_FILE} NEED_BOOST_SERIALIZATION)
   if (NOT (${NEED_BOOST_SERIALIZATION} EQUAL -1))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,8 +86,10 @@ set(CMAKE_CXX_STANDARD 14)
 foreach(TEST_FILE ${TEST_SRCS})
   SET(TEST_EXE "${TEST_FILE}.x")
   add_executable(${TEST_EXE} ${TEST_FILE})
-  # Newer compilers give waring in boost/archive/helper_collection.hpp and fail so -Werror can't be used
+  # Newer compilers give waring in boost/archive/helper_collection.hpp and others for deprecated constructors
+  # so -Werror can't be used
   target_compile_options(${TEST_EXE} PUBLIC -Wall -Wextra -Wfatal-errors) #-Wpedantic
+  #i.e. the directory above the <REPOROOT>/test directory, then you can build anywhere you like outside of the source
   target_include_directories(${TEST_EXE} PUBLIC "${CMAKE_PROJECT_SOURCE_DIR}/..")
 
   list(FIND NEED_BOOST_SERIALIZATION_SRCS ${TEST_FILE} NEED_BOOST_SERIALIZATION)


### PR DESCRIPTION
A couple of small changes in the test/CMakeLists.txt to actually allow building from an arbitrary directory properly using the cmake. i.e.
```
whatever/dir/ectory/build $ cmake path/to/mpi3/test
```
And removing -Werror since at least with clang16 b-mpi3 is not warning free.
```
/usr/local/include/boost/random/detail/polynomial.hpp:303:20: fatal error: definition of implicit copy constructor for 'reference' is
      deprecated because it has a user-provided copy assignment operator [-Wdeprecated-copy-with-user-provided-copy]
        reference &operator=(const reference &other)
                   ^
/usr/local/include/boost/random/detail/polynomial.hpp:315:16: note: in implicit copy constructor for
      'boost::random::detail::polynomial::reference' first required here
        return reference(_storage[i/bits], i%bits);
               ^
1 error generated.
```